### PR TITLE
UDP: Add option to disable touchpad

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,7 +48,7 @@ How to use
 The driver supports all versions of Sony DualShock 4 controllers (I use
 DS4v2) connected via USB or Bluetooth.
 
-My version of ds4drv has 4 additional command line arguments (all are
+My version of ds4drv has 5 additional command line arguments (all are
 optional):
 
 -  ``--udp`` -- starts UDP server. Without this flag ds4drv acts just
@@ -57,6 +57,7 @@ optional):
    (default: 127.0.0.1);
 -  ``--udp-port`` -- UDP port on which server will be listening
    (default: 26760);
+-  ``--udp-no-touch`` -- do not send touchpad touches to UDP clients;
 -  ``--udp-remap-buttons`` -- an option for those, who doesn’t like
    Nintendo’s button layout. It just swaps A↔B and X↔Y buttons only for
    UDP clients.

--- a/ds4drv/actions/input.py
+++ b/ds4drv/actions/input.py
@@ -28,6 +28,8 @@ ReportAction.add_option("--udp", action="store_true",
                         help="Listen for connections from Cemuhook via UDP")
 ReportAction.add_option("--udp-host", metavar="IP", default="127.0.0.1",
                         help="Interface that will accept UDP connections")
+ReportAction.add_option("--udp-no-touch", action="store_true",
+                        help="Do not send touchpad touches to UDP clients")
 ReportAction.add_option("--udp-port", metavar="PORT", type=int, default=26760,
                         help="Port that will be listened by the UDP server")
 ReportAction.add_option("--udp-remap-buttons", action="store_true",
@@ -98,6 +100,7 @@ class ReportActionInput(ReportAction):
             if options.udp and not self.server:
                 self.server = UDPServer(options.udp_host, options.udp_port)
                 self.server.remap = options.udp_remap_buttons
+                self.server.send_touch = not options.udp_no_touch
                 self.server.start()
 
             self.joystick.ignored_buttons = set()

--- a/ds4drv/servers/udp.py
+++ b/ds4drv/servers/udp.py
@@ -44,6 +44,7 @@ class UDPServer:
         self.counter = 0
         self.clients = dict()
         self.remap = False
+        self.send_touch = True
 
     def _res_ports(self, index):
         return Message('ports', [
@@ -173,23 +174,31 @@ class UDPServer:
 
             report.r2_analog,
             report.l2_analog,
-
-            report.trackpad_touch0_active * 0xFF,
-            report.trackpad_touch0_id,
-
-            report.trackpad_touch0_x & 255,
-            report.trackpad_touch0_x >> 8,
-            report.trackpad_touch0_y & 255,
-            report.trackpad_touch0_y >> 8,
-
-            report.trackpad_touch1_active * 0xFF,
-            report.trackpad_touch1_id,
-
-            report.trackpad_touch1_x & 255,
-            report.trackpad_touch1_x >> 8,
-            report.trackpad_touch1_y & 255,
-            report.trackpad_touch1_y >> 8,
         ])
+
+        if self.send_touch:
+            data.extend([
+                report.trackpad_touch0_active * 0xFF,
+                report.trackpad_touch0_id,
+
+                report.trackpad_touch0_x & 255,
+                report.trackpad_touch0_x >> 8,
+                report.trackpad_touch0_y & 255,
+                report.trackpad_touch0_y >> 8,
+
+                report.trackpad_touch1_active * 0xFF,
+                report.trackpad_touch1_id,
+
+                report.trackpad_touch1_x & 255,
+                report.trackpad_touch1_x >> 8,
+                report.trackpad_touch1_y & 255,
+                report.trackpad_touch1_y >> 8,
+            ])
+        else:
+            data.extend([
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+                0x00, 0x00, 0x00, 0x00, 0x00, 0x00
+            ])
 
         data.extend(bytes(struct.pack('<Q', int(time() * 10**6))))
 


### PR DESCRIPTION
Add a new flag --udp-no-touch, which disables sending touchpad touches. This can be useful to prevent effects of accidental touches in Cemu, which maps the touchpad as the Wii U Gamepad's touchscreen. (It's generally easier to use the mouse anyway.)

Tested in Splatoon (Cemu 1.21.2) and PadTest 1011