### PR TITLE
Improve compatibility with pad-motion

### DIFF
--- a/ds4drv/servers/udp.py
+++ b/ds4drv/servers/udp.py
@@ -174,7 +174,7 @@ class UDPServer:
             report.r2_analog,
             report.l2_analog,
 
-            report.trackpad_touch0_active * 0xFF,
+            report.trackpad_touch0_active,
             report.trackpad_touch0_id,
 
             report.trackpad_touch0_x & 255,
@@ -182,7 +182,7 @@ class UDPServer:
             report.trackpad_touch0_y & 255,
             report.trackpad_touch0_y >> 8,
 
-            report.trackpad_touch1_active * 0xFF,
+            report.trackpad_touch1_active,
             report.trackpad_touch1_id,
 
             report.trackpad_touch1_x & 255,

--- a/ds4drv/servers/udp.py
+++ b/ds4drv/servers/udp.py
@@ -49,7 +49,7 @@ class UDPServer:
         return Message('ports', [
             index,  # pad id
             0x02,  # state (connected)
-            0x03,  # model (generic)
+            0x02,  # gyro (full gyro)
             0x01,  # connection type (usb)
             0x00, 0x00, 0x00, 0x00, 0x00, 0xff,  # MAC 00:00:00:00:00:FF
             0xef,  # battery (charged)
@@ -112,7 +112,7 @@ class UDPServer:
         data = [
             0x00,  # pad id
             0x02,  # state (connected)
-            0x02,  # model (generic)
+            0x02,  # gyro (full gyro)
             0x01,  # connection type (usb)
             0x00, 0x00, 0x00, 0x00, 0x00, 0xff,  # MAC 00:00:00:00:00:FF
             0xef,  # battery (charged)


### PR DESCRIPTION
pad-motion is a Rust library, and its Cemuhook protocol implementation is rather strict and ignores messages with invalid values. These changes correct some values.