### PR TITLE
Update config.py to replace SafeConfigParser with ConfigParser

### DIFF
--- a/ds4drv/actions/input.py
+++ b/ds4drv/actions/input.py
@@ -80,7 +80,7 @@ class ReportActionInput(ReportAction):
                 if joystick.device.device:
                     self.logger.info("Created devices {0} (joystick) "
                                      "{1} (evdev) ", joystick.joystick_dev,
-                                     joystick.device.device.fn)
+                                     joystick.device.device.path)
             else:
                 joystick = None
 

--- a/ds4drv/config.py
+++ b/ds4drv/config.py
@@ -81,7 +81,7 @@ udpopt.add_argument("--udp-remap-buttons", action="store_true",
 controllopt = parser.add_argument_group("controller options")
 
 
-class Config(configparser.SafeConfigParser):
+class Config(configparser.ConfigParser):
     def load(self, filename):
         self.read([filename])
 
@@ -108,7 +108,7 @@ class Config(configparser.SafeConfigParser):
             return {}
 
     def sections(self, prefix=None):
-        for section in configparser.SafeConfigParser.sections(self):
+        for section in configparser.ConfigParser.sections(self):
             match = re.match(r"{0}:(.+)".format(prefix), section)
             if match:
                 yield match.group(1), section


### PR DESCRIPTION
SafeConfigParser has been deprecated in favor of ConfigParser, causing an error when trying to run with python 3.12. Changing to ConfigParser fixes this issue.